### PR TITLE
Feat: Handle comma/dot display

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -32,7 +32,7 @@ var init = function(network, provider, prefix) {
 var updateTotal = function() {
     paymentCycle.selectedPeriods = $('#end_epoch').find(':selected').data('index');
 
-    var payment_amount = parseInt($('#payment_amount').val());
+    var payment_amount = parseFloat($('#payment_amount').val());
     if (isNaN(payment_amount)) payment_amount = 0;
 
     var periods = parseInt((paymentCycle.selectedPeriods+1)-paymentCycle.selectedStartIndex);
@@ -59,6 +59,12 @@ $(document).ready(function() {
 
     $('#end_epoch').change(function() {
         updateTotal();
+    });
+    
+    $('#payment_amount').on('input',function(){
+      //As of now, core doesn't handle comma, but handle dots. Therefore we change it to the user.
+      var payment_amount_value = $('#payment_amount').val();
+      $('#payment_amount').val(payment_amount_value.replace(/,/g, '.'));
     });
 
     $('#payment_amount').change(function() {


### PR DESCRIPTION
Following a display bug : 

Core handle comma number, but the proposal creation process display amount as an int. 
Also, one could (in Europe) misuse comma instead of dot.
This PR fixes two case : 
- Display exact number (as Float)
- Correct comma to dot for the user

Here the process one would expect : 
 
When Alice want to receive 15.4 Dash, and that she enters "15," before having time to enter 4, the comma is changed to a dot (so 15, => 15.). 
Therefore she will have a visual feedback instead of us handling that in an hidden way after her pressing "createProposal".



Before : 

![proposal_1](https://user-images.githubusercontent.com/5849920/32009740-31324bc6-b9b0-11e7-8e1c-7e11640806de.gif)


After : 


![proposal_2 2](https://user-images.githubusercontent.com/5849920/32009924-a4732af6-b9b0-11e7-8d64-d5cf7c3655d2.gif)
