### PR TITLE
Fix : payment_amount, start/end_epoch types

### DIFF
--- a/js/proposalGenerator.js
+++ b/js/proposalGenerator.js
@@ -8,9 +8,10 @@ function ProposalGenerator(gov) {
     this.gov.name = $('#name').val().trim();
     this.gov.url = $('#url').val().trim();
     this.gov.payment_address = $('#payment_address').val().trim();
-    this.gov.payment_amount = $('#payment_amount').val().trim();
-    this.gov.start_epoch = $('#start_epoch').val();
-    this.gov.end_epoch = $('#end_epoch').val();
+    this.gov.payment_amount = parseFloat($('#payment_amount').val().trim());
+    this.gov.start_epoch = parseInt($('#start_epoch').val());
+    this.gov.end_epoch = parseInt($('#end_epoch').val());
+
 
     // hidden elements
     this.gov.type = parseInt($('#type').val());


### PR DESCRIPTION
Fixes : https://github.com/dashevo/proposal-generator/issues/25

If a string is entered as a payment amount, the proposal page will handle it as being invalid and will give the necessary feedback. 
It's not the case for the start/end epoch fields, but only someone playing with the select field will be able to make such a modification, therefore he will already have the Developer console opened, and will there see "Invalid date" error message. 