### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ RUN apk add --update --no-cache git
 
 WORKDIR /app
 
-COPY . /app/
+COPY package.json /app/
 
 RUN npm install --quiet
+
+COPY . /app/
+
 RUN npm run linebreak-check
 RUN npm run build
 


### PR DESCRIPTION
Small build improvements using Docker.

1) It doesn't copy the `node_modules` from the host machine anymore
    Reason: we shouldn't trust the `node_modules` directory from outside, it's always better to let the node version that's inside the container download it's own.

2) Improves incremental build times, by not installing npm modules on every file change.

Let me know what your thoughts are on this.
@nmarley @Alex-Werner 
  